### PR TITLE
修正zypper包管理部分

### DIFF
--- a/docs/misc/java-install.md
+++ b/docs/misc/java-install.md
@@ -71,12 +71,12 @@ sudo dnf -y install java-21-amazon-corretto-devel
 
 #### Zypper
 
-Zypper 用于 openSUSE、SLES 及相关发行版。
+Zypper 用于 openSUSE、SLE 及相关发行版。
+
+由于 zypper 不能导入 yum 软件库，因此暂时以系统官方所提供软件源的软件作为演示。
 
 ```bash
-sudo zypper addrepo https://yum.corretto.aws/corretto.repo
-sudo zypper refresh
-sudo zypper install java-21-amazon-corretto-devel
+sudo zypper in java-21-openjdk
 ```
 
 #### YUM

--- a/docs/misc/java-install.md
+++ b/docs/misc/java-install.md
@@ -73,7 +73,7 @@ sudo dnf -y install java-21-amazon-corretto-devel
 
 Zypper 用于 openSUSE、SLE 及相关发行版。
 
-由于 zypper 不能导入 yum 软件库，因此暂时以系统官方所提供软件源的软件作为演示。
+由于 Zypper 不能导入 YUM 软件库，因此暂时以系统官方所提供软件源的软件作为演示。
 
 ```bash
 sudo zypper in java-21-openjdk

--- a/docs/misc/java-install.md
+++ b/docs/misc/java-install.md
@@ -73,7 +73,7 @@ sudo dnf -y install java-21-amazon-corretto-devel
 
 Zypper 用于 openSUSE、SLE 及相关发行版。
 
-由于 Zypper 不能导入 YUM 软件库，因此暂时以系统官方所提供软件源的软件作为演示。
+由于不能直接用 Zypper 导入 YUM 软件库，因此暂时以系统官方所提供软件源的软件作为演示。
 
 ```bash
 sudo zypper in java-21-openjdk


### PR DESCRIPTION
zypper理应不能直接导入yum软件源，我暂时用官方源软件做了替代

常规方法应该是和dotnet一样用rpm导入的来着，但没有电脑去验证我设想的步骤所以没有写正确安装correcto的方法而是直接换成了官方源jdk

（虽然也可以简单归结为我懒且随性）

拿得到电脑了我回去改pr去（有点莫名其妙的画饼，因为电脑算是被正式没收了拿到的可能性不大）